### PR TITLE
Support latest version of zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,12 +4,9 @@ pub fn build(b: *std.Build) void {
     const mode = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
 
-    b.addModule(.{
-        .name = "serial",
+    const serial_module = b.createModule(.{
         .source_file = .{ .path = "src/serial.zig" },
     });
-
-    const serial_module = b.modules.get("serial") orelse unreachable;
 
     const echo_exe = b.addExecutable(.{
         .name = "serial-echo",
@@ -18,7 +15,7 @@ pub fn build(b: *std.Build) void {
         .optimize = mode,
     });
     echo_exe.addModule("serial", serial_module);
-    echo_exe.install();
+    b.installArtifact(echo_exe);
 
     const list_exe = b.addExecutable(.{
         .name = "serial-list",
@@ -27,5 +24,5 @@ pub fn build(b: *std.Build) void {
         .optimize = mode,
     });
     list_exe.addModule("serial", serial_module);
-    list_exe.install();
+    b.installArtifact(list_exe);
 }

--- a/src/serial.zig
+++ b/src/serial.zig
@@ -45,7 +45,7 @@ const WindowsPortIterator = struct {
     }
 
     pub fn deinit(self: *Self) void {
-        RegCloseKey(self.key);
+        _ = RegCloseKey(self.key);
         self.* = undefined;
     }
 


### PR DESCRIPTION
As zig changes, so must the code...  These changes allow the serial library + examples to compile on both Linux and Windows when using the latest version of zig.