### PR TITLE
MacOS support

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -15,11 +15,15 @@ pub fn build(b: *std.build.Builder) void {
     echo_exe.setTarget(target);
     echo_exe.setBuildMode(mode);
     echo_exe.addPackage(pkgs.serial);
+    if (target.isDarwin())
+        echo_exe.linkLibC();
     echo_exe.install();
 
     const list_exe = b.addExecutable("serial-list", "examples/list.zig");
     list_exe.setTarget(target);
     list_exe.setBuildMode(mode);
     list_exe.addPackage(pkgs.serial);
+    if (target.isDarwin())
+        echo_exe.linkLibC();
     list_exe.install();
 }


### PR DESCRIPTION
Added support for macOS.
All test pass on macOS.
Only `/dev/cu.*` ports work properly.
Requires linking against libc to access `tcflush()`, but I believe that is the default for macOS.

PS: Please review this carefully as I am a total novice in Zig(I mostly do embedded C).